### PR TITLE
Mattias/communication with axiomtek and avantes

### DIFF
--- a/Dialogs/FileTransferDlg.cpp
+++ b/Dialogs/FileTransferDlg.cpp
@@ -47,7 +47,6 @@ UINT DownloadFileListWithSerial(LPVOID pParam)
     dlg->m_fileStatusEdit.SetWindowText("Downloading file list ...");
     time(&tStart);
 
-
     if (!dlg->m_SerialController->InitCommunication('B')) {
         dlg->m_busy = false;
         return 0;
@@ -73,10 +72,9 @@ UINT DownloadFileListWithSerial(LPVOID pParam)
     pFileTransferDlg->ClearOut();
     pFileTransferDlg->ParseDir(pFileTransferDlg->m_textA, pFileTransferDlg->m_fileListA);
     pFileTransferDlg->ParseDir(pFileTransferDlg->m_textB, pFileTransferDlg->m_fileListB);
-
     pFileTransferDlg->PostMessage(WM_UPDATE_FILE_TREE);
-
     dlg->m_busy = false;
+
     return 0;
 }
 
@@ -84,6 +82,12 @@ UINT DownloadFileListWithSerial(LPVOID pParam)
 UINT DownloadFileListWithFTP(LPVOID pParam)
 {
     CFileTransferDlg* dlg = (CFileTransferDlg*)pParam;
+
+    dlg->m_busy = true;
+    dlg->m_fileStatusEdit.SetWindowText("Downloading file list ...");
+
+    time_t tStart;
+    time(&tStart);
 
     /** Get the list for 'B'-disk */
     if (dlg->m_ftpController->GetDiskFileList(1))
@@ -103,21 +107,35 @@ UINT DownloadFileListWithFTP(LPVOID pParam)
         }
     }
     else
+    {
         MessageBox(NULL, "Can not get ftp file list", "Notice", MB_OK);
-
-    // Pause a little bit, for the small FTP-server to have time to recover...
-    Sleep(1000);
+    }
 
     /** Get the list for 'A'-disk */
-    if (dlg->m_ftpController->GetDiskFileList(0))
+    if (dlg->m_ftpController->m_electronicsBox == BOX_VERSION_1)
     {
-        for (const CScannerFileInfo& info : dlg->m_ftpController->m_fileInfoList)
-        {
-            pFileTransferDlg->m_fileListA.AddTail(new CScannerFileInfo(info));
-        }
+        // Pause a little bit, for the small FTP-server to have time to recover...
+        Sleep(1000);
 
-        pFileTransferDlg->PostMessage(WM_UPDATE_FILE_TREE);
+        if (dlg->m_ftpController->GetDiskFileList(0))
+        {
+            for (const CScannerFileInfo& info : dlg->m_ftpController->m_fileInfoList)
+            {
+                pFileTransferDlg->m_fileListA.AddTail(new CScannerFileInfo(info));
+            }
+        }
     }
+
+    time_t tStop;
+    time(&tStop);
+    CString msg;
+    msg.Format("Finsh downloading file list\r\nUsed %d seconds", static_cast<int>(tStop - tStart));
+    dlg->m_fileStatusEdit.SetWindowText(msg);
+
+    // Update the user interface
+    pFileTransferDlg->PostMessage(WM_UPDATE_FILE_TREE);
+    dlg->m_busy = false;
+
     return 0;
 }
 //download file by serial connection
@@ -920,62 +938,71 @@ BOOL CFileTransferDlg::OnInitDialog()
     // EXCEPTION: OCX Property Pages should return FALSE
 }
 
+bool ExistsDiskA(Communication::CSerialControllerWithTx* m_SerialController, Communication::CFTPHandler* m_ftpController)
+{
+    if (m_SerialController != nullptr)
+    {
+        return m_SerialController->m_electronicsBox == BOX_VERSION_1;
+    }
+    else
+    {
+        return false;
+    }
+}
+
 LRESULT CFileTransferDlg::OnUpdateFileTree(WPARAM wParam, LPARAM lParam)
 {
     CString fileFullName, folderName, subfix;
-    HTREEITEM hTRootA, hTRootB, hTItem, hTItem2;
+    HTREEITEM hTRootA, hTItem, hTItem2;
     m_fileTree.DeleteAllItems();
 
     POSITION listPos;
     CScannerFileInfo* fileInfo;
     fileInfo = NULL;
-    int i = 0;
     CString folderFlag;
     folderFlag.Format("DIR");
 
-    //ClearOut();
-    //ParseDir(m_textA,'A');
-    //ParseDir(m_textB,'B');
-    if (!(m_SerialController != NULL && m_SerialController->m_electronicsBox == BOX_VERSION_2))
+    if (ExistsDiskA(m_SerialController, m_ftpController))
     {
-        hTRootA = AddOneItem((HTREEITEM)NULL, "Disk A", (HTREEITEM)
-            TVI_ROOT, 0);
+        hTRootA = AddOneItem((HTREEITEM)NULL, "Disk A", (HTREEITEM)TVI_ROOT, 0);
         m_fileTree.SetItemImage(hTRootA, 0, 0);
         listPos = m_fileListA.GetHeadPosition();
-        while (listPos != NULL)
+        int elementIdx = 0;
+        while (listPos != nullptr)
         {
             fileInfo = m_fileListA.GetNext(listPos);
             fileFullName.Format("%s.%s", (LPCSTR)fileInfo->fileName, (LPCSTR)fileInfo->fileSuffix);
-            hTItem = AddOneItem(hTRootA, (LPTSTR)(LPCTSTR)fileFullName, (HTREEITEM)TVI_LAST, 2 * (i + 1));
+            hTItem = AddOneItem(hTRootA, (LPTSTR)(LPCTSTR)fileFullName, (HTREEITEM)TVI_LAST, 2 * (elementIdx + 1));
             SetFileItemImage(hTItem, fileInfo->fileSuffix);
-            i++;
+            elementIdx++;
         }
     }
 
-    hTRootB = AddOneItem((HTREEITEM)NULL, "Disk B", (HTREEITEM)
-        TVI_ROOT, 1);
+    HTREEITEM hTRootB = AddOneItem((HTREEITEM)NULL, "Data", (HTREEITEM)TVI_ROOT, 1);
 
     m_fileTree.SetItemImage(hTRootB, 0, 0);
-    i = 0;
     listPos = m_fileListB.GetHeadPosition();
-    while (listPos != NULL)
+
+    int elementIdx = 0;
+    while (listPos != nullptr)
     {
         fileInfo = m_fileListB.GetNext(listPos);
 
         fileFullName.Format("%s.%s", (LPCSTR)fileInfo->fileName, (LPCSTR)fileInfo->fileSuffix);
 
-        hTItem = AddOneItem(hTRootB, (LPTSTR)(LPCTSTR)fileFullName, (HTREEITEM)TVI_LAST, 2 * (i + 1));
+        hTItem = AddOneItem(hTRootB, (LPTSTR)(LPCTSTR)fileFullName, (HTREEITEM)TVI_LAST, 2 * (elementIdx + 1));
         SetFileItemImage(hTItem, fileInfo->fileSuffix);
-        i++;
+        elementIdx++;
     }
+
     listPos = m_folderListB.GetHeadPosition();
     while (listPos != NULL)
     {
         CScannerFolderInfo *folderInfo = m_folderListB.GetNext(listPos);
         folderName.Format("%s", (LPCSTR)folderInfo->folderName);
-        hTItem = AddOneItem(hTRootB, (LPTSTR)(LPCTSTR)folderName, (HTREEITEM)TVI_LAST, 2 * (i + 1));
+        hTItem = AddOneItem(hTRootB, (LPTSTR)(LPCTSTR)folderName, (HTREEITEM)TVI_LAST, 2 * (elementIdx + 1));
         SetFileItemImage(hTItem, folderFlag);
-        i++;
+        elementIdx++;
 
         // Also fill in the file information in the folder, if any...
         POSITION folderListPos = folderInfo->m_fileList.GetHeadPosition();
@@ -983,15 +1010,19 @@ LRESULT CFileTransferDlg::OnUpdateFileTree(WPARAM wParam, LPARAM lParam)
             CScannerFileInfo *fileInfo = folderInfo->m_fileList.GetNext(folderListPos);
             fileFullName.Format("%s.%s", (LPCSTR)fileInfo->fileName, (LPCSTR)fileInfo->fileSuffix);
 
-            hTItem2 = AddOneItem(hTItem, (LPTSTR)(LPCTSTR)fileFullName, (HTREEITEM)TVI_LAST, 2 * (i + 1));
+            hTItem2 = AddOneItem(hTItem, (LPTSTR)(LPCTSTR)fileFullName, (HTREEITEM)TVI_LAST, 2 * (elementIdx + 1));
             SetFileItemImage(hTItem2, fileInfo->fileSuffix);
-            i++;
+            elementIdx++;
         }
         if (folderInfo->m_fileList.GetSize() > 0)
             m_fileTree.Expand(hTItem, TVE_EXPAND);
     }
 
-    m_fileTree.Expand(hTRootA, TVE_EXPAND);
+
+    if (ExistsDiskA(m_SerialController, m_ftpController))
+    {
+        m_fileTree.Expand(hTRootA, TVE_EXPAND);
+    }
     m_fileTree.Expand(hTRootB, TVE_EXPAND);
 
     m_busy = false;
@@ -1470,15 +1501,30 @@ void CFileTransferDlg::OnLbnSelchangeScannerList()
         break;
         //when it is ftp connection
     case FTP_CONNECTION:
-        m_ftpController = new Communication::CFTPHandler();
+        m_ftpController = new Communication::CFTPHandler(g_settings.scanner[curScanner].electronicsBox);
 
-        m_ftpController->SetFTPInfo(curScanner,
-            g_settings.scanner[curScanner].comm.ftpHostName,
-            g_settings.scanner[curScanner].comm.ftpUserName,
-            g_settings.scanner[curScanner].comm.ftpPassword,
-            admUserName,
-            admPwd,
-            g_settings.scanner[curScanner].comm.timeout / 1000);
+        if (g_settings.scanner[curScanner].electronicsBox != BOX_VERSION_4)
+        {
+            m_ftpController->SetFTPInfo(curScanner,
+                g_settings.scanner[curScanner].comm.ftpHostName,
+                g_settings.scanner[curScanner].comm.ftpUserName,
+                g_settings.scanner[curScanner].comm.ftpPassword,
+                g_settings.scanner[curScanner].comm.ftpAdminUserName,
+                g_settings.scanner[curScanner].comm.ftpAdminPassword,
+                g_settings.scanner[curScanner].comm.timeout / 1000);
+        }
+        else
+        {
+            // The Axiomtek box has only one login.
+            m_ftpController->SetFTPInfo(curScanner,
+                g_settings.scanner[curScanner].comm.ftpHostName,
+                g_settings.scanner[curScanner].comm.ftpUserName,
+                g_settings.scanner[curScanner].comm.ftpPassword,
+                g_settings.scanner[curScanner].comm.ftpUserName,
+                g_settings.scanner[curScanner].comm.ftpPassword,
+                g_settings.scanner[curScanner].comm.timeout / 1000);
+        }
+
         AfxBeginThread(DownloadFileListWithFTP, this, THREAD_PRIORITY_NORMAL, 0, 0, NULL);
         break;
     default:

--- a/Dialogs/FileTransferDlg.cpp
+++ b/Dialogs/FileTransferDlg.cpp
@@ -91,12 +91,12 @@ UINT DownloadFileListWithFTP(LPVOID pParam)
         // Update the lists...
         pFileTransferDlg->ClearOut();
 
-        POSITION pos = dlg->m_ftpController->m_fileInfoList.GetHeadPosition();
-        while (pos != NULL) {
-            CScannerFileInfo *fileInfo = new CScannerFileInfo(dlg->m_ftpController->m_fileInfoList.GetNext(pos));
-            pFileTransferDlg->m_fileListB.AddTail(fileInfo);
+        for (const CScannerFileInfo& info : dlg->m_ftpController->m_fileInfoList)
+        {
+            pFileTransferDlg->m_fileListB.AddTail(new CScannerFileInfo(info));
         }
-        pos = dlg->m_ftpController->m_rFolderList.GetHeadPosition();
+
+        auto pos = dlg->m_ftpController->m_rFolderList.GetHeadPosition();
         while (pos != NULL) {
             CScannerFolderInfo *folderInfo = new CScannerFolderInfo('B', dlg->m_ftpController->m_rFolderList.GetNext(pos), "", "");
             pFileTransferDlg->m_folderListB.AddTail(folderInfo);
@@ -111,10 +111,9 @@ UINT DownloadFileListWithFTP(LPVOID pParam)
     /** Get the list for 'A'-disk */
     if (dlg->m_ftpController->GetDiskFileList(0))
     {
-        POSITION pos = dlg->m_ftpController->m_fileInfoList.GetHeadPosition();
-        while (pos != NULL) {
-            CScannerFileInfo *fileInfo = new CScannerFileInfo(dlg->m_ftpController->m_fileInfoList.GetNext(pos));
-            pFileTransferDlg->m_fileListA.AddTail(fileInfo);
+        for (const CScannerFileInfo& info : dlg->m_ftpController->m_fileInfoList)
+        {
+            pFileTransferDlg->m_fileListA.AddTail(new CScannerFileInfo(info));
         }
 
         pFileTransferDlg->PostMessage(WM_UPDATE_FILE_TREE);
@@ -294,7 +293,7 @@ UINT DownloadFolderWithSerial(LPVOID pParam)
         CScannerFileInfo *folderItem = list->GetNext(pos);
 
         // the name and size of the remote file to download
-        fileName.Format("%s.%s", (LPCSTR)folderItem->fileName, (LPCSTR)folderItem->fileSubfix);
+        fileName.Format("%s.%s", (LPCSTR)folderItem->fileName, (LPCSTR)folderItem->fileSuffix);
         fileSize = folderItem->fileSize;
 
         // Download the file
@@ -370,7 +369,7 @@ UINT DownloadFolderWithFTP(LPVOID pParam)
         CScannerFileInfo *folderItem = list->GetNext(pos);
 
         // the name and size of the remote file to download
-        fileName.Format("%s.%s", (LPCSTR)folderItem->fileName, (LPCSTR)folderItem->fileSubfix);
+        fileName.Format("%s.%s", (LPCSTR)folderItem->fileName, (LPCSTR)folderItem->fileSuffix);
         fileFullName.Format("%s%s", (LPCSTR)dlg->m_storagePath, (LPCSTR)fileName);
 
         msg.Format("Begin to download %s from %s", (LPCSTR)fileName, (LPCSTR)dlg->m_ftpController->m_ftpInfo.hostName);
@@ -599,10 +598,9 @@ UINT ExpandFolderByFTP(LPVOID pParam)
     msg.Format("Finsh downloading file list\r\nUsed %d seconds", static_cast<int>(tStop - tStart));
     dlg->m_fileStatusEdit.SetWindowText(msg);
 
-    pos = dlg->m_ftpController->m_fileInfoList.GetHeadPosition();
-    while (pos != NULL) {
-        CScannerFileInfo *fileInfo = new CScannerFileInfo(dlg->m_ftpController->m_fileInfoList.GetNext(pos));
-        list->AddTail(fileInfo);
+    for (const CScannerFileInfo& info : dlg->m_ftpController->m_fileInfoList)
+    {
+        list->AddTail(new CScannerFileInfo(info));
     }
 
     dlg->m_ftpController->Disconnect();
@@ -947,9 +945,9 @@ LRESULT CFileTransferDlg::OnUpdateFileTree(WPARAM wParam, LPARAM lParam)
         while (listPos != NULL)
         {
             fileInfo = m_fileListA.GetNext(listPos);
-            fileFullName.Format("%s.%s", (LPCSTR)fileInfo->fileName, (LPCSTR)fileInfo->fileSubfix);
+            fileFullName.Format("%s.%s", (LPCSTR)fileInfo->fileName, (LPCSTR)fileInfo->fileSuffix);
             hTItem = AddOneItem(hTRootA, (LPTSTR)(LPCTSTR)fileFullName, (HTREEITEM)TVI_LAST, 2 * (i + 1));
-            SetFileItemImage(hTItem, fileInfo->fileSubfix);
+            SetFileItemImage(hTItem, fileInfo->fileSuffix);
             i++;
         }
     }
@@ -964,10 +962,10 @@ LRESULT CFileTransferDlg::OnUpdateFileTree(WPARAM wParam, LPARAM lParam)
     {
         fileInfo = m_fileListB.GetNext(listPos);
 
-        fileFullName.Format("%s.%s", (LPCSTR)fileInfo->fileName, (LPCSTR)fileInfo->fileSubfix);
+        fileFullName.Format("%s.%s", (LPCSTR)fileInfo->fileName, (LPCSTR)fileInfo->fileSuffix);
 
         hTItem = AddOneItem(hTRootB, (LPTSTR)(LPCTSTR)fileFullName, (HTREEITEM)TVI_LAST, 2 * (i + 1));
-        SetFileItemImage(hTItem, fileInfo->fileSubfix);
+        SetFileItemImage(hTItem, fileInfo->fileSuffix);
         i++;
     }
     listPos = m_folderListB.GetHeadPosition();
@@ -983,10 +981,10 @@ LRESULT CFileTransferDlg::OnUpdateFileTree(WPARAM wParam, LPARAM lParam)
         POSITION folderListPos = folderInfo->m_fileList.GetHeadPosition();
         while (folderListPos != NULL) {
             CScannerFileInfo *fileInfo = folderInfo->m_fileList.GetNext(folderListPos);
-            fileFullName.Format("%s.%s", (LPCSTR)fileInfo->fileName, (LPCSTR)fileInfo->fileSubfix);
+            fileFullName.Format("%s.%s", (LPCSTR)fileInfo->fileName, (LPCSTR)fileInfo->fileSuffix);
 
             hTItem2 = AddOneItem(hTItem, (LPTSTR)(LPCTSTR)fileFullName, (HTREEITEM)TVI_LAST, 2 * (i + 1));
-            SetFileItemImage(hTItem2, fileInfo->fileSubfix);
+            SetFileItemImage(hTItem2, fileInfo->fileSuffix);
             i++;
         }
         if (folderInfo->m_fileList.GetSize() > 0)
@@ -1309,7 +1307,7 @@ void CFileTransferDlg::FillList(CString &token, CList <CScannerFileInfo*, CScann
         {
         case 0: fileInfo->fileName = resToken;
             break;
-        case 1: fileInfo->fileSubfix = resToken;
+        case 1: fileInfo->fileSuffix = resToken;
             break;
         case 2: fileInfo->fileSize = atoi(resToken);
             break;

--- a/Dialogs/FileTransferDlg.cpp
+++ b/Dialogs/FileTransferDlg.cpp
@@ -978,7 +978,7 @@ LRESULT CFileTransferDlg::OnUpdateFileTree(WPARAM wParam, LPARAM lParam)
         }
     }
 
-    HTREEITEM hTRootB = AddOneItem((HTREEITEM)NULL, "Data", (HTREEITEM)TVI_ROOT, 1);
+    HTREEITEM hTRootB = AddOneItem((HTREEITEM)NULL, "Disk B", (HTREEITEM)TVI_ROOT, 1);
 
     m_fileTree.SetItemImage(hTRootB, 0, 0);
     listPos = m_fileListB.GetHeadPosition();

--- a/Dialogs/FileTransferDlg.cpp
+++ b/Dialogs/FileTransferDlg.cpp
@@ -90,7 +90,7 @@ UINT DownloadFileListWithFTP(LPVOID pParam)
     time(&tStart);
 
     /** Get the list for 'B'-disk */
-    if (dlg->m_ftpController->GetDiskFileList(1))
+    if (dlg->m_ftpController->GetDiskFileList('B'))
     {
         // Update the lists...
         pFileTransferDlg->ClearOut();
@@ -100,10 +100,9 @@ UINT DownloadFileListWithFTP(LPVOID pParam)
             pFileTransferDlg->m_fileListB.AddTail(new CScannerFileInfo(info));
         }
 
-        auto pos = dlg->m_ftpController->m_rFolderList.GetHeadPosition();
-        while (pos != NULL) {
-            CScannerFolderInfo *folderInfo = new CScannerFolderInfo('B', dlg->m_ftpController->m_rFolderList.GetNext(pos), "", "");
-            pFileTransferDlg->m_folderListB.AddTail(folderInfo);
+        for (const CString& folder: dlg->m_ftpController->m_rFolderList)
+        {
+            pFileTransferDlg->m_folderListB.AddTail(new CScannerFolderInfo('B', folder, "", ""));
         }
     }
     else
@@ -117,7 +116,7 @@ UINT DownloadFileListWithFTP(LPVOID pParam)
         // Pause a little bit, for the small FTP-server to have time to recover...
         Sleep(1000);
 
-        if (dlg->m_ftpController->GetDiskFileList(0))
+        if (dlg->m_ftpController->GetDiskFileList('A'))
         {
             for (const CScannerFileInfo& info : dlg->m_ftpController->m_fileInfoList)
             {

--- a/Dialogs/FileTransferDlg.h
+++ b/Dialogs/FileTransferDlg.h
@@ -2,7 +2,6 @@
 #include "afxwin.h"
 
 #include "../Communication/SerialControllerWithTx.h"
-
 #include "../Communication/FTPHandler.h"
 #include "../FileTreeCtrl.h"
 #include "../ScannerFileInfo.h"
@@ -10,11 +9,8 @@
 #include "afxcmn.h"
 #include "afxtempl.h"
 
-namespace Dialogs{
-
-	const enum COMMUNICATION_TYPE {SERIAL_CABLE, FREEWAVE_PXP, FREEWAVE_PMP, ETHERNET};
-
-	// CFileTransferDlg dialog
+namespace Dialogs
+{
 	class CFileTransferDlg : public CDialog
 	{
 		DECLARE_DYNAMIC(CFileTransferDlg)
@@ -54,20 +50,25 @@ namespace Dialogs{
 		/** The list of configured scanning systems */
 		CListBox m_scannerList;
 
-		/**array to store file information*/
+		/** array to store file information */
 		CList <CScannerFileInfo*, CScannerFileInfo*> m_fileListA;
 		CList <CScannerFileInfo*, CScannerFileInfo*> m_fileListB;
 		
 		/** list of Rxxx folders */
 		CList<CScannerFolderInfo*, CScannerFolderInfo*> m_folderListB;
 
-		/** The serial controller, which makes it possible to upload/download data */
-		Communication::CSerialControllerWithTx *m_SerialController;
+        /** The serial controller, which makes it possible to upload/download through serial. */
+        Communication::CSerialControllerWithTx *m_SerialController = nullptr;
 
-		Communication::CFTPHandler *m_ftpController;
-		int m_communicationType;
+        /** The ftp-controller, which makes it possible to upload/download through FTP */
+        Communication::CFTPHandler* m_ftpController = nullptr;
+
+        /** The type of communication, must be either SERIAL_CONNECTION or FTP_CONNECTION */
+        int m_communicationType = SERIAL_CONNECTION;
+
 		/**selected item text*/
 		CString m_selItemText;
+
 		//--------------------------------------------//
 		//------------public functions----------------//
 		//--------------------------------------------//

--- a/ScannerFileInfo.cpp
+++ b/ScannerFileInfo.cpp
@@ -8,7 +8,7 @@ CScannerFileInfo::CScannerFileInfo()
 CScannerFileInfo::CScannerFileInfo(char pDiskName, CString pFileName, CString pFileSubfix, long pFileSize, CString pDate, CString pTime)
     : diskName(pDiskName),
     fileName(pFileName),
-    fileSubfix(pFileSubfix),
+    fileSuffix(pFileSubfix),
     fileSize(pFileSize),
     date(pDate),
     time(pTime)
@@ -18,7 +18,7 @@ CScannerFileInfo::CScannerFileInfo(char pDiskName, CString pFileName, CString pF
 CScannerFileInfo::CScannerFileInfo(const CScannerFileInfo &info2)
     : diskName(info2.diskName),
     fileName(info2.fileName),
-    fileSubfix(info2.fileSubfix),
+    fileSuffix(info2.fileSuffix),
     fileSize(info2.fileSize),
     date(info2.date),
     time(info2.time)
@@ -33,7 +33,7 @@ CScannerFileInfo& CScannerFileInfo::operator=(const CScannerFileInfo& info2)
     this->diskName = info2.diskName;
     this->fileName.Format(info2.fileName);
     this->fileSize = info2.fileSize;
-    this->fileSubfix.Format(info2.fileSubfix);
+    this->fileSuffix.Format(info2.fileSuffix);
     this->time.Format(info2.time);
     return *this;
 }

--- a/ScannerFileInfo.h
+++ b/ScannerFileInfo.h
@@ -13,10 +13,13 @@ public:
 
     char diskName;
 
-    CString	fileName;
+    /** The filename, without the suffix */
+    CString fileName;
 
-    CString fileSubfix;
+    /** The file suffix */
+    CString fileSuffix;
 
+    /** The size of the file, in bytes */
     long fileSize;
 
     CString date;

--- a/communication/CommunicationController.cpp
+++ b/communication/CommunicationController.cpp
@@ -243,7 +243,6 @@ UINT ConnectByFTP(LPVOID pParam)
             g_settings.scanner[mainIndex].comm.timeout / 1000);
     }
 
-
     spectrometerSerialID.Format("%s", (LPCSTR)g_settings.scanner[mainIndex].spec[0].serialNumber);
 
     while (g_runFlag)

--- a/communication/FTPCom.cpp
+++ b/communication/FTPCom.cpp
@@ -328,6 +328,25 @@ BOOL CFTPCom::EnterFolder(const CString& folder)
         return FALSE;
     }
 
+    // The top-level directory is treated separately due to different responses from different instruments
+    if (Equals(folder, "//"))
+    {
+        if (Equals(currentFolder, "/") || Equals(currentFolder, "//"))
+        {
+            CString msg;
+            msg.Format("Get into folder %s", (LPCSTR)folder);
+            ShowMessage(msg);
+            return TRUE;
+        }
+        else
+        {
+            CString msg;
+            msg.Format("Can not get into folder %s", (LPCSTR)folder);
+            ShowMessage(msg);
+            return FALSE;
+        }
+    }
+
     // The response we want to have...
     CString folderResponseOption1, folderResponseOption2;
     folderResponseOption1.Format("/%s/", (LPCSTR)folder);

--- a/communication/FTPCom.cpp
+++ b/communication/FTPCom.cpp
@@ -156,7 +156,7 @@ bool CFTPCom::DownloadAFile(LPCTSTR remoteFile, LPCTSTR fileFullName)
     try
     {
         // Try to download the file
-        BOOL r = m_FtpConnection->GetFile(remoteFile, fileFullName, FALSE);
+        BOOL r = m_FtpConnection->GetFile(remoteFile, fileFullName, FALSE, FILE_ATTRIBUTE_NORMAL, FTP_TRANSFER_TYPE_BINARY | INTERNET_FLAG_RELOAD);
         bool result = (r == TRUE);
 
         if (!result)

--- a/communication/FTPCom.h
+++ b/communication/FTPCom.h
@@ -34,10 +34,9 @@ namespace Communication
 
         int CreateDirectory(LPCTSTR remoteDirectory);
 
-        /**find file in the current ftp folder
-        *return TRUE if exists
-        */
-        int FindFile(CString& fileName);
+        /** Searches for a file in the current folder in the instrument.
+            @return true if the file does exist. */
+        bool FindFile(const CString& fileName);
 
         /*Remove a folder*/
         BOOL DeleteFolder(const CString& folder);

--- a/communication/FTPHandler.cpp
+++ b/communication/FTPHandler.cpp
@@ -115,8 +115,8 @@ bool CFTPHandler::PollScanner()
 
 bool CFTPHandler::DownloadPakFiles(const CString& folder, std::vector<CScannerFileInfo>& fileInfoList)
 {
-    const CString workPak = "WORK.PAK";
-    const CString uploadPak = "upload.pak";
+    const CString workPak = "WORK.PAK";  // case here doesn't matter since the comparison below is case insensitive
+    const CString uploadPak = "upload.pak";  // case here doesn't matter since the comparison below is case insensitive
 
     if (Connect(m_ftpInfo.hostName, m_ftpInfo.userName, m_ftpInfo.password, m_ftpInfo.timeout) != 1)
     {
@@ -552,6 +552,8 @@ bool CFTPHandler::DownloadSpectrumFile(const CString& remoteFile, const CString&
     // Check that the size on disk is same as the size in the remote computer
     if (Common::RetrieveFileSize(localFileFullPath) != remoteFileSize)
     {
+        m_statusMsg.Format("Error while downloading file (%s) by FTP, local file size does not agree with remote", (LPCSTR)m_ftpInfo.hostName);
+        ShowMessage(m_statusMsg);
         return false;
     }
 
@@ -574,7 +576,8 @@ bool CFTPHandler::DownloadSpectrumFile(const CString& remoteFile, const CString&
         {
             ShowMessage("The pak file is corrupted");
             //DELETE remote file
-            if (0 == DeleteRemoteFile(remoteFile)) {
+            if (0 == DeleteRemoteFile(remoteFile))
+            {
                 m_statusMsg.Format("<node %d> Remote File %s could not be removed", m_mainIndex, (LPCSTR)remoteFile);
                 ShowMessage(m_statusMsg);
             }
@@ -641,9 +644,6 @@ bool CFTPHandler::DownloadFile(const CString& remoteFileName, const CString& loc
     {
         DeleteFile(fileFullName);
     }
-
-    m_statusMsg.Format("Begin to download file from %s", (LPCSTR)m_ftpInfo.hostName);
-    ShowMessage(m_statusMsg);
 
     //show running lamp on interface
     pView->PostMessage(WM_SCANNER_RUN, (WPARAM)&(m_spectrometerSerialID), 0);

--- a/communication/FTPHandler.cpp
+++ b/communication/FTPHandler.cpp
@@ -282,7 +282,7 @@ bool CFTPHandler::DownloadOldPak(long interval)
     return true;
 }
 
-long CFTPHandler::GetPakFileList(CString& folder)
+long CFTPHandler::GetPakFileList(const CString& folder)
 {
     CString fileList, listFilePath, msg;
     CFTPSocket ftpSocket(m_ftpInfo.timeout);

--- a/communication/FTPHandler.cpp
+++ b/communication/FTPHandler.cpp
@@ -282,14 +282,10 @@ bool CFTPHandler::DownloadOldPak(long interval)
     return true;
 }
 
-//download file list from B disk
 long CFTPHandler::GetPakFileList(CString& folder)
 {
     CString fileList, listFilePath, msg;
     CFTPSocket ftpSocket(m_ftpInfo.timeout);
-
-    char ipAddr[16];
-    sprintf(ipAddr, "%s", (LPCSTR)m_ftpInfo.hostName);
 
     // Start with clearing out the list of files...
     m_fileInfoList.RemoveAll();
@@ -299,7 +295,7 @@ long CFTPHandler::GetPakFileList(CString& folder)
     ftpSocket.SetLogFileName(listFilePath);
 
     // Log in to the instrument's FTP-server
-    if (!ftpSocket.Login(ipAddr, m_ftpInfo.userName, m_ftpInfo.password))
+    if (!ftpSocket.Login(m_ftpInfo.hostName, m_ftpInfo.userName, m_ftpInfo.password))
     {
         return -1;
     }

--- a/communication/FTPHandler.cpp
+++ b/communication/FTPHandler.cpp
@@ -60,7 +60,6 @@ CFTPHandler::~CFTPHandler(void)
     ShowMessage(message);
 }
 
-/**set ftp information*/
 void CFTPHandler::SetFTPInfo(int mainIndex, const CString& hostname, const CString& userName, const CString &pwd, int timeOut, long portNumber)
 {
     this->m_mainIndex = mainIndex;
@@ -102,15 +101,6 @@ void CFTPHandler::SetFTPInfo(int mainIndex, const CString& IP, const CString& us
     }
 
     this->SetFTPInfo(mainIndex, IP, userName, pwd, timeOut, portNumber);
-}
-
-bool CFTPHandler::PollScanner()
-{
-    CString msg;
-    msg.Format("<node %d> Checking for files to download", m_mainIndex);
-    ShowMessage(msg);
-
-    return DownloadAllOldPak();
 }
 
 bool CFTPHandler::DownloadPakFiles(const CString& folder, std::vector<CScannerFileInfo>& fileInfoList)
@@ -171,9 +161,12 @@ bool CFTPHandler::DownloadPakFiles(const CString& folder, std::vector<CScannerFi
     return true;
 }
 
-bool CFTPHandler::DownloadAllOldPak()
+bool CFTPHandler::PollScanner()
 {
     CString msg;
+    msg.Format("<node %d> Checking for files to download", m_mainIndex);
+    ShowMessage(msg);
+
     CString folder = "";
 
     // get file and folder list

--- a/communication/FTPHandler.cpp
+++ b/communication/FTPHandler.cpp
@@ -362,19 +362,22 @@ bool CFTPHandler::GetDiskFileList(int disk)
 {
     CString fileList, listFilePath;
     CFTPSocket ftpSocket;
-    char ipAddr[16];
-    sprintf(ipAddr, "%s", (LPCSTR)m_ftpInfo.hostName);
     listFilePath.Format("%sfileList.txt", (LPCSTR)m_storageDirectory);
     ftpSocket.SetLogFileName(listFilePath);
 
-
-    if (disk == 1) {
-        if (!ftpSocket.Login(ipAddr, m_ftpInfo.userName, m_ftpInfo.password))
+    if (disk == 1)
+    {
+        if (!ftpSocket.Login(m_ftpInfo.hostName, m_ftpInfo.userName, m_ftpInfo.password))
+        {
             return false;
+        }
     }
-    else {
-        if (!ftpSocket.Login(ipAddr, m_ftpInfo.adminUserName, m_ftpInfo.adminPassword))
+    else
+    {
+        if (!ftpSocket.Login(m_ftpInfo.hostName, m_ftpInfo.adminUserName, m_ftpInfo.adminPassword))
+        {
             return false;
+        }
     }
 
     if (ftpSocket.GetFileList())

--- a/communication/FTPHandler.h
+++ b/communication/FTPHandler.h
@@ -55,9 +55,9 @@ namespace Communication
              a command.txt file to it */
         void WakeUp();
 
-        // --------------- DOWNLOADING OF THE SPECTRA ---------------------
+        // --------------- DOWNLOADING DATA ---------------------
 
-        /** Download a file from the instrument computer.
+        /** Download a file (pak file or other type) from the instrument computer.
             @param remoteFileName The name of the file to download from the instrument.
                 This shall be a file in the current directory and include the file extension. 
             @param localDirectory The local directory to which the file should be downloaded.
@@ -67,20 +67,20 @@ namespace Communication
 
         /** Delete one file in the instrument.
             @param remote file name (without path)
-            @return TRUE if deleted successfully */
-        BOOL DeleteRemoteFile(const CString& remoteFile);
+            @return true if deleted successfully */
+        bool DeleteRemoteFile(const CString& remoteFile);
 
         // ----------------- HANDLING THE FILE-LISTS -------------------
 
         /** Retrieves the list of files from the given directory,
-                calls 'FillFileList' which rebuilds the lists
-                'm_fileInfoList' and 'm_rFolderList'.
-                @param disk - the disk to retrieve the file-list from,
-                    '0' corresponds to program/configuration-disk
-                    '1' corresponds to data-disk
-                --------- This function is only called from the CFileTransferDlg ---------
+            calls 'FillFileList' which rebuilds the lists
+            'm_fileInfoList' and 'm_rFolderList'.
+        @param disk - the disk to retrieve the file-list from,
+            'A' corresponds to program/configuration-disk
+            'B' corresponds to data-disk
+        --------- This function is only called from the CFileTransferDlg ---------
                 */
-        bool GetDiskFileList(int disk = 1);
+        bool GetDiskFileList(char disk = 'B');
 
         /** Retrieves the list of pak files from the given directory on the instrument.
             This will call 'FillFileList' which rebuilds the two lists
@@ -105,7 +105,7 @@ namespace Communication
         std::vector<CScannerFileInfo> m_fileInfoList;
 
         /** The list of RXX folders in the current directory */
-        CList<CString, CString &> m_rFolderList;
+        std::vector<CString> m_rFolderList;
 
         /** The kind of electronics box that we're communicating with.
             This is necessary since different models of boxes behave differently. */

--- a/communication/FTPHandler.h
+++ b/communication/FTPHandler.h
@@ -71,14 +71,28 @@ namespace Communication
 
         // --------------- DOWNLOADING OF THE SPECTRA ---------------------
 
-        /** Download a file in the remote computer */
-        bool DownloadFile(const CString &remoteFileName, const CString &savetoPath);
+        /** Download a file from the instrument computer.
+            @param remoteFileName The name of the file to download from the instrument.
+                This shall be a file in the current directory and include the file extension. 
+            @param localDirectory The local directory to which the file should be downloaded.
+                This must exist prior to calling this method.
+            @param remoteFileSize The size of the file on the instrument, in bytes. */
+        bool DownloadFile(const CString& remoteFileName, const CString& localDirectory, long remoteFileSize);
 
-        /**download upload.pak, Uxxx.pak files and evaluate*/
-        bool DownloadSpectra(const CString &remoteFile, const CString &savetoPath);
+        /** Downloads a single .pak file from the instrument and deletes it from the instrument.
+            This will verify that the file size is correct and that the file can be parsed properly.
+            @param remoteFile The name of the file to download in the instrument,
+                including the .pak file extension.
+            @param localDirectory The local directory where the file should be saved.
+                This must exist prior to calling this method.
+            @param remoteFileSize The size of the file in the remote system, in bytes.
+            @return true if the file was successfully downloaded and 
+                the size of the downloaded file equals the remote file size and
+                the file can be parsed properly. */
+        bool DownloadSpectrumFile(const CString& remoteFile, const CString& localDirectory, long remoteFileSize);
 
-        /* Downloads all Uxxx.pak files found in the m_fileInfoList.*/
-        bool DownloadPakFiles(const CString& folder);
+        /* Downloads all Uxxx.pak files found in the provided list of files.*/
+        bool DownloadPakFiles(const CString& folder, std::vector<CScannerFileInfo>& fileInfoList);
 
         /*download all old pak files*/
         bool DownloadAllOldPak();
@@ -148,8 +162,6 @@ namespace Communication
 
         /** Information on this connection */
         struct FTPInformation m_ftpInfo;
-
-        long m_remoteFileSize;
 
         /** The index of this device in the configuration.xml.
             Used to retrieve settings for the device. */

--- a/communication/FTPHandler.h
+++ b/communication/FTPHandler.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <afxtempl.h>
+#include <vector>
 #include "../communication/ftpcom.h"
 #include "../communication/ftpsocket.h"
 #include "../Common/Spectra/PakFileHandler.h"
@@ -122,11 +123,12 @@ namespace Communication
             @return true if the line represents a .pak-file or folder which may contain .pak-files */
         bool ParseFileInfo(CString line, char disk = 'B');
 
-        /** Extracts the suffix (file extension) of a file-name.
-            @param fileName The file to get the suffix from
-            @param fileSuffix Will on successful return be filled with the suffix
-            @return true If the suffix could be parsed. */
-        static bool GetSuffix(const CString& fileName, CString& fileSuffix);
+        /** Extracts and removes the suffix (file extension) of a file-name and puts it into the provided string.
+            @param fileName The file to get the suffix from.
+                This will be modified to not contain the suffix.
+            @param fileSuffix Will on successful return be filled with the suffix.
+                If no suffix is found, then this will be empty.*/
+        static void ExtractSuffix(CString& fileName, CString& fileSuffix);
 
         /** Removes all stored file-information from
                     m_fileInfoList and m_rFolderList */
@@ -164,7 +166,7 @@ namespace Communication
         CString m_statusMsg;
 
         /** The list of files in the current directory */
-        CList<CScannerFileInfo, CScannerFileInfo&> m_fileInfoList;
+        std::vector<CScannerFileInfo> m_fileInfoList;
 
         /** The list of RXX folders in the current directory */
         CList<CString, CString &> m_rFolderList;

--- a/communication/FTPHandler.h
+++ b/communication/FTPHandler.h
@@ -35,24 +35,17 @@ namespace Communication
         //--------------public functions ------------//
         //-------------------------------------------//
 
-        /**set ftp information*/
+        /** Sets the necessary connection information for us to be able 
+            to create an FTP connection */
         void SetFTPInfo(int mainIndex, const CString& hostName, const CString& userName, const CString &pwd, int timeOut, long portNumber = 5551);
         void SetFTPInfo(int mainIndex, const CString& hostName, const CString& userName, const CString &pwd, const CString &admUserName, const CString &admPwd, int timeOut, long portNumber = 5551);
 
-        /**poll one instrument*/
+        /** Polls the connected instrument for new data. 
+            This will attempt to download all old UXXX.pak spectrum files and
+            enter the RXXX directories in search of data. */
         bool PollScanner();
 
         // ---------------- MANAGING THE INSTRUMENT ------------------
-
-        /** Send a command to kongo.exe in the instrument
-             by creating a command.txt file and upload it to the instrument.
-             @return true if the file creation and upload was successful. */
-        bool SendCommand(const char* cmd);
-
-        /** Creates a command.txt file to upload to the instrument
-            containing the provided command to send.
-            @return true if the file could be created successfully. */
-        static bool MakeCommandFile(const CString& fileName, const char* command);
 
         /** Tells the instrument to go to sleep by uploading
              a command.txt file to it */
@@ -61,13 +54,6 @@ namespace Communication
         /** Tells the instrument to wake up by uploading
              a command.txt file to it */
         void WakeUp();
-
-        /** reboot the remote scanner */
-        void Reboot();
-
-        /** Download cfg.txt from the instrument.
-            @return 1 if successful, otherwise 0*/
-        int DownloadCfgTxt();
 
         // --------------- DOWNLOADING OF THE SPECTRA ---------------------
 
@@ -78,27 +64,6 @@ namespace Communication
                 This must exist prior to calling this method.
             @param remoteFileSize The size of the file on the instrument, in bytes. */
         bool DownloadFile(const CString& remoteFileName, const CString& localDirectory, long remoteFileSize);
-
-        /** Downloads a single .pak file from the instrument and deletes it from the instrument.
-            This will verify that the file size is correct and that the file can be parsed properly.
-            @param remoteFile The name of the file to download in the instrument,
-                including the .pak file extension.
-            @param localDirectory The local directory where the file should be saved.
-                This must exist prior to calling this method.
-            @param remoteFileSize The size of the file in the remote system, in bytes.
-            @return true if the file was successfully downloaded and 
-                the size of the downloaded file equals the remote file size and
-                the file can be parsed properly. */
-        bool DownloadSpectrumFile(const CString& remoteFile, const CString& localDirectory, long remoteFileSize);
-
-        /* Downloads all Uxxx.pak files found in the provided list of files.*/
-        bool DownloadPakFiles(const CString& folder, std::vector<CScannerFileInfo>& fileInfoList);
-
-        /*download all old pak files*/
-        bool DownloadAllOldPak();
-
-        /**download old pak files and evaluate*/
-        bool DownloadOldPak(long interval);
 
         /** Delete one file in the instrument.
             @param remote file name (without path)
@@ -117,44 +82,11 @@ namespace Communication
                 */
         bool GetDiskFileList(int disk = 1);
 
-        /** Retrieves the list of files from the given directory on the instrument.
+        /** Retrieves the list of pak files from the given directory on the instrument.
             This will call 'FillFileList' which rebuilds the two lists
                 'm_fileInfoList' and 'm_rFolderList'
             @return the number of pak-files in the given folder. */
         long GetPakFileList(const CString& folder);
-
-        /** Use the result from the file-listing command to build 
-            the lists of files inside the current directory of the instrument.
-            This rebuilds the lists 'm_fileInfoList' and 'm_rFolderList'.
-            @param fileName The local filename where the result of the file-listing
-                command has been saved. 
-            @param disk The disk on the remote device where the file listing was done.
-            @return The number of found .pak files or directories which may contain .pak files. */
-        int FillFileList(const CString& fileName, char disk = 'B');
-
-        /** Parse one line in the result of the file-listing command 
-            and inserts it into the appropriate list (either m_fileInfoList or m_rFolderList).
-            @return true if the line represents a .pak-file or folder which may contain .pak-files */
-        bool ParseFileInfo(CString line, char disk = 'B');
-
-        /** Extracts and removes the suffix (file extension) of a file-name and puts it into the provided string.
-            @param fileName The file to get the suffix from.
-                This will be modified to not contain the suffix.
-            @param fileSuffix Will on successful return be filled with the suffix.
-                If no suffix is found, then this will be empty.*/
-        static void ExtractSuffix(CString& fileName, CString& fileSuffix);
-
-        /** Removes all stored file-information from
-                    m_fileInfoList and m_rFolderList */
-        void EmptyFileInfo();
-
-        /** Parse one line in the result of the file-listing command and if the 
-            result is a folder which may contain .pak-files then the name
-            of the folder is added to the list m_rfolderList.
-            Only folders of the format RXXX will be inserted.
-            @param line One line from the result of the file-listing command.
-            @return true if the folder name may contain .pak-files. */
-        bool AddFolderInfo(const CString& line);
 
         //-------------------------------------------//
         //--------------public variables ------------//
@@ -166,14 +98,6 @@ namespace Communication
         /** The index of this device in the configuration.xml.
             Used to retrieve settings for the device. */
         int m_mainIndex;
-
-        /** The spectrometer's serial number,
-            used to identify the instrument when communicating with other parts of the program. */
-        CString m_spectrometerSerialID;
-
-        /** The temporary storage directory on the local computer where we 
-            temporarily store downloaded files */
-        CString m_storageDirectory;
 
         CString m_statusMsg;
 
@@ -187,13 +111,96 @@ namespace Communication
             This is necessary since different models of boxes behave differently. */
         ELECTRONICS_BOX m_electronicsBox;
 
-        /** Statistics on the speed to download file, in kilo-bytes/second*/
-        double m_dataSpeed;
-
     private:
+
+        //-------------------------------------------//
+        //------------ private functions ------------//
+        //-------------------------------------------//
+
+        /** Send a command to kongo.exe in the instrument
+             by creating a command.txt file and upload it to the instrument.
+             @return true if the file creation and upload was successful. */
+        bool SendCommand(const char* cmd);
+
+        /** Creates a command.txt file to upload to the instrument
+            containing the provided command to send.
+            @return true if the file could be created successfully. */
+        static bool MakeCommandFile(const CString& fileName, const char* command);
+
+        /** Reboots the remote scanner */
+        void Reboot();
+
+        /** Download cfg.txt from the instrument.
+            @return 1 if successful, otherwise 0*/
+        int DownloadCfgTxt();
+
+        /** Downloads a single .pak file from the instrument and deletes it from the instrument.
+            This will verify that the file size is correct and that the file can be parsed properly.
+            @param remoteFile The name of the file to download in the instrument,
+                including the .pak file extension.
+            @param localDirectory The local directory where the file should be saved.
+                This must exist prior to calling this method.
+            @param remoteFileSize The size of the file in the remote system, in bytes.
+            @return true if the file was successfully downloaded and
+                the size of the downloaded file equals the remote file size and
+                the file can be parsed properly. */
+        bool DownloadSpectrumFile(const CString& remoteFile, const CString& localDirectory, long remoteFileSize);
+
+        /* Downloads all Uxxx.pak files found in the provided list of files.*/
+        bool DownloadPakFiles(const CString& folder, std::vector<CScannerFileInfo>& filesToDownload);
+
+        /** download old pak files and evaluate*/
+        bool DownloadOldPak(long interval);
+
+        /** Use the result from the file-listing command to build
+            the lists of files inside the current directory of the instrument.
+            This rebuilds the lists 'm_fileInfoList' and 'm_rFolderList'.
+            @param fileName The local filename where the result of the file-listing
+                command has been saved.
+            @param disk The disk on the remote device where the file listing was done.
+            @return The number of found .pak files or directories which may contain .pak files. */
+        int FillFileList(const CString& fileName, char disk = 'B');
+
+        /** Parse one line in the result of the file-listing command
+            and inserts it into the appropriate list (either m_fileInfoList or m_rFolderList).
+            @return true if the line represents a .pak-file or folder which may contain .pak-files */
+        bool ParseFileInfo(CString line, char disk = 'B');
+
+        /** Extracts and removes the suffix (file extension) of a file-name and puts it into the provided string.
+            @param fileName The file to get the suffix from.
+                This will be modified to not contain the suffix.
+            @param fileSuffix Will on successful return be filled with the suffix.
+                If no suffix is found, then this will be empty.*/
+        static void ExtractSuffix(CString& fileName, CString& fileSuffix);
+
+        /** Removes all stored file-information from m_fileInfoList and m_rFolderList */
+        void EmptyFileInfo();
+
+        /** Parse one line in the result of the file-listing command and if the
+            result is a folder which may contain .pak-files then the name
+            of the folder is added to the list m_rfolderList.
+            Only folders of the format RXXX will be inserted.
+            @param line One line from the result of the file-listing command.
+            @return true if the folder name may contain .pak-files. */
+        bool AddFolderInfo(const CString& line);
+
+        //-------------------------------------------//
+        //---------------- private data -------------//
+        //-------------------------------------------//
 
         /** The name of the file used to send commands to kongo in the instrument. */
         const CString m_commandFileName = "command.txt";
+
+        /** The temporary storage directory on the local computer where we
+            temporarily store downloaded files */
+        CString m_storageDirectory;
+
+        /** The spectrometer's serial number,
+            used to identify the instrument when communicating with other parts of the program. */
+        CString m_spectrometerSerialID;
+
+        /** Statistics on the speed to download file, in kilo-bytes/second*/
+        double m_dataSpeed;
 
     };
 }

--- a/communication/FTPHandler.h
+++ b/communication/FTPHandler.h
@@ -76,7 +76,7 @@ namespace Communication
         /**download upload.pak, Uxxx.pak files and evaluate*/
         bool DownloadSpectra(const CString &remoteFile, const CString &savetoPath);
 
-        /*download Uxxx.pak files on m_fileInfoList*/
+        /* Downloads all Uxxx.pak files found in the m_fileInfoList.*/
         bool DownloadPakFiles(const CString& folder);
 
         /*download all old pak files*/
@@ -102,10 +102,11 @@ namespace Communication
                 */
         bool GetDiskFileList(int disk = 1);
 
-        /** Retrieves the list of files from the given directory,
-                calls 'FillFileList' which rebuilds the lists
-                'm_fileInfoList' and 'm_rFolderList' */
-        long GetPakFileList(CString& folder);
+        /** Retrieves the list of files from the given directory on the instrument.
+            This will call 'FillFileList' which rebuilds the two lists
+                'm_fileInfoList' and 'm_rFolderList'
+            @return the number of pak-files in the given folder. */
+        long GetPakFileList(const CString& folder);
 
         /** Use the result from the file-listing command to build 
             the lists of files inside the current directory of the instrument.

--- a/communication/FTPSocket.h
+++ b/communication/FTPSocket.h
@@ -70,14 +70,14 @@ namespace Communication
 
 		bool SendFileToServer(CString& fileLocalPath);
 
-		/**Login FTP server
-		   @ftpServerIP - ip address of ftp server
-		   @ftpPort - ftp server's port , for control channel, standard is 21.
-		   @userName - login name
-		   @pwd - login password
-		   @return true if successful
-		*/
-		bool Login(const CString ftpServerIP, CString userName, CString pwd, int ftpPort = 21);
+        /**Login to one FTP server
+            @param ftpServerIPOrHostName - ip address or hostname of the ftp server.
+                Maximum length of this string is 255 characters.
+            @param userName - Login name
+            @param pwd - Login password
+            @param ftpPort - ftp server's port, for control channel, standard is 21.
+            @return true if successful */
+        bool Login(const CString& ftpServerIPOrHostName, const CString& userName, const CString& pwd, int ftpPort = 21);
 
 		/**Get system type*/
 		void GetSysType(CString& type);
@@ -199,7 +199,7 @@ namespace Communication
 		/**data structure to store ftp server parameters*/
 		struct ftpParam
 		{
-			char m_serverIP[64];
+			char m_serverIP[256];
 			int m_serverPort;
 			int m_serverDataPort;
 			CString userName;

--- a/communication/FTPSocket.h
+++ b/communication/FTPSocket.h
@@ -21,14 +21,7 @@ namespace Communication
 		// ---------------------- PUBLIC METHODS --------------------------------
 		// ----------------------------------------------------------------------
 
-		/**Send command to FTP server
-		  @command - the standard commands that are listed in RFC 959
-		  @commandText - the parameters to be set in this command. 
-		   When there is no parameter to be used, this value is "".
-		  @return the error code if this thread's last Windows Sockets operation failed.
-		  @return 0 if successful.
-		*/
-		int SendCommand(CString command, CString commandText);
+
 
 		/**Connect FTP server
 		   @usedSocket - the socket to be used to make connection
@@ -38,10 +31,10 @@ namespace Communication
 		*/
 		bool Connect(SOCKET& usedSocket, char* serverIP, int serverPort);
 
-		/**Read the control response from the server, write message to m_serverMsg
-		    @return true if there is response
-		*/
-		int ReadResponse();
+        /** Read the control response from the server, write message to m_serverMsg
+            @return +1 If there is response.
+            @return -1 If no response is received. */
+        int ReadResponse();
 
 		/**Read data from the FTP server*/
 		bool ReadData();
@@ -82,8 +75,9 @@ namespace Communication
 		/**Get system type*/
 		void GetSysType(CString& type);
 
-		/*Enter one folder*/
-		bool EnterFolder(CString& folder);
+        /** Enter one folder from the current working directory.
+            @return true on success. */
+        bool EnterFolder(const CString& folder);
 
 		/*Go to upper folder*/
 		bool GoToUpperFolder();
@@ -91,8 +85,11 @@ namespace Communication
 		/**Enter passive mode*/
 		bool EnterPassiveMode();
 
-		/**Send list command to the FTP server*/
-		bool List();
+        /** Send the List command to the FTP server.
+            This will list all files in the current directory.
+            The result will be written to the file specified by 'm_listFileName'
+            @return true if the operation succeeded. */
+        bool List();
 
 		/**Send nlst command to the FTP server*/
 		bool NameList();
@@ -187,7 +184,7 @@ namespace Communication
 		// ----------------------------------------------------------------------
 		// ---------------------- PUBLIC DATA -----------------------------------
 		// ----------------------------------------------------------------------
-	public:
+
 		/**special socket for control connection */
 		SOCKET m_controlSocket;
 
@@ -231,5 +228,18 @@ namespace Communication
 
 		/**list to store the ftp codes which indicate the status of last communication */
 		CList<int,int> m_ftpCode;
+
+        // ----------------------------------------------------------------------
+        // ---------------------- PRIVATE METHODS -------------------------------
+        // ----------------------------------------------------------------------
+
+        /**Send command to FTP server
+          @command - the standard commands that are listed in RFC 959
+          @commandText - the parameters to be set in this command.
+           When there is no parameter to be used, this value is "".
+          @return the error code if this thread's last Windows Sockets operation failed.
+          @return 0 if successful.
+        */
+        int SendCommand(const CString &command, const CString& commandText);
 	};
 }


### PR DESCRIPTION
Large corrections to the FTPHandler class:

- Implemented full support for Axiomtec+Avaspec instrument
- Corrected one problem where the size of the downloaded file did not agree with the size reported by the FTP-Server
- Restructured the FTPHandler class by adding many more comments on what the functions really do, making functions/data which are only used internally by the class private.
- Simplified and corrected several parts in the FTPHandler 
- Corrected one bug where it was not possible to use a hostname (in stead of IP-number) to connect to an instrument via FTP
- Corrected one bug where using a hostname of more than 16 characters would cause the NovacProgram to crash.
- Resurrected the File Transfer dialog such that it is able to list .pak-files in the Axiomtec device and download/upload files to the instrument. 